### PR TITLE
Fallback to default sans serif font.

### DIFF
--- a/Source/CustomLookAndFeel.cpp
+++ b/Source/CustomLookAndFeel.cpp
@@ -83,8 +83,14 @@ juce::Label* CustomLookAndFeel::createSliderTextBox (juce::Slider& slider)
 
 juce::Font CustomLookAndFeel::getTextButtonFont (juce::TextButton&, int buttonHeight)
 {
-    juce::Font font ("Avenir Next Medium", 90.f, 0);
-    return { font };
+    juce::String name = "Avenir Next Medium";
+    if (juce::Font::findAllTypefaceNames().contains("Avenir Next Medium")) {
+        juce::Font font (name, 90.f, 0);
+        return { font };
+    } else {
+        juce::Font font (juce::Font::getDefaultSansSerifFontName(), 50.f, 0);
+        return { font };
+    }
 }
 
 void CustomLookAndFeel::drawButtonBackground (juce::Graphics& g, juce::Button& button, const juce::Colour& backgroundColour,

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -18,7 +18,9 @@ SimpleReverbAudioProcessorEditor::SimpleReverbAudioProcessorEditor (SimpleReverb
       dwSliderAttachment (audioProcessor.apvts, "Dry/Wet", dwSlider),
       freezeAttachment (audioProcessor.apvts, "Freeze", freezeButton)
 {
-    juce::LookAndFeel::getDefaultLookAndFeel().setDefaultSansSerifTypefaceName ("Avenir Next Medium");
+    juce::String name = "Avenir Next Medium";
+    if (juce::Font::findAllTypefaceNames ().contains (name))
+      juce::LookAndFeel::getDefaultLookAndFeel().setDefaultSansSerifTypefaceName (name);
 
     setSize (500, 250);
     setWantsKeyboardFocus (true);


### PR DESCRIPTION
In CustomLookAndFeel a fixed font is used which seems non-free and
not always available on systems. It is also used to override the
default UI fonts overall. Every text labels are then gone if it
does not exist.

So, set the font only if it exists.