### PR TITLE
Changed to Component::keyPressed

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -21,7 +21,6 @@ SimpleReverbAudioProcessorEditor::SimpleReverbAudioProcessorEditor (SimpleReverb
     juce::LookAndFeel::setDefaultLookAndFeel (&customLookAndFeel);
     setSize (560, 300);
     setWantsKeyboardFocus (true);
-    addKeyListener (this);
 
     sizeLabel.setText ("size", juce::NotificationType::dontSendNotification);
     sizeLabel.attachToComponent (&sizeSlider, false);
@@ -69,7 +68,7 @@ void SimpleReverbAudioProcessorEditor::resized()
     dwSlider.setBounds     (440, 130, 70, 70);
 }
 
-bool SimpleReverbAudioProcessorEditor::keyPressed (const juce::KeyPress& key, juce::Component* comp)
+bool SimpleReverbAudioProcessorEditor::keyPressed (const juce::KeyPress& key)
 {
     auto cmdZ      = juce::KeyPress ('z', juce::ModifierKeys::commandModifier, 0);
     auto cmdShiftZ = juce::KeyPress ('z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0);

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -17,7 +17,7 @@
 //==============================================================================
 /**
 */
-class SimpleReverbAudioProcessorEditor  : public juce::AudioProcessorEditor, public juce::KeyListener
+class SimpleReverbAudioProcessorEditor  : public juce::AudioProcessorEditor
 {
 public:
     SimpleReverbAudioProcessorEditor (SimpleReverbAudioProcessor&, juce::UndoManager& um);
@@ -27,7 +27,7 @@ public:
     void paint (juce::Graphics&) override;
     void resized() override;
 
-    bool keyPressed (const juce::KeyPress& key, juce::Component* comp) override;
+    bool keyPressed (const juce::KeyPress& key) override;
 
 private:
     SimpleReverbAudioProcessor& audioProcessor;


### PR DESCRIPTION
The implementation using the keyPressed function of the Component class is simpler than the implementation using the keyPressed function of the KeyListener class.