### PR TITLE
Fixed undo/redo actions

### DIFF
--- a/Source/Components/RotarySlider.cpp
+++ b/Source/Components/RotarySlider.cpp
@@ -105,5 +105,10 @@ bool RotarySlider::keyPressed (const juce::KeyPress& k)
         }
     }
 
+    /** If we implement it to return true, the undo/redo shortcuts implemented in the keyPressed function
+        of the parent component will not work properly when RotarySlider component has KeyboardFocus.
+        This is because the keypress event will be consumed only by this component.
+        By returning false, the event will be passed to the parent component, and the undo/redo shortcuts will work properly.
+    */
     return false;
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -70,11 +70,10 @@ void SimpleReverbAudioProcessorEditor::resized()
 
 bool SimpleReverbAudioProcessorEditor::keyPressed (const juce::KeyPress& key)
 {
-    auto cmdZ      = juce::KeyPress ('z', juce::ModifierKeys::commandModifier, 0);
-    auto cmdShiftZ = juce::KeyPress ('z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0);
+    if (key == cmdZ && undoManager.canUndo())
+        undoManager.undo();
+    if (key == cmdShiftZ && undoManager.canRedo())
+        undoManager.redo();
 
-    if (key == cmdZ) undoManager.undo();
-    if (key == cmdShiftZ) undoManager.redo();
-
-    return false;
+    return true;
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -55,5 +55,8 @@ private:
 
     CustomLookAndFeel customLookAndFeel;
 
+    juce::KeyPress cmdZ { 'z', juce::ModifierKeys::commandModifier, 0 };
+    juce::KeyPress cmdShiftZ { 'z', juce::ModifierKeys::commandModifier | juce::ModifierKeys::shiftModifier, 0 };
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (SimpleReverbAudioProcessorEditor)
 };


### PR DESCRIPTION
Solved the problem of undo/redo actions not working properly by changing the return value of the keyPressed function of the PluginEditor component from false to true.

closes #22 